### PR TITLE
pyopenssl 21.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,12 +17,19 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
-    - cryptography >=2.8
+    - cryptography >=3.3
     - six >=1.5.2
 
 test:
+  requires:
+    - python <3.10
+    - pip
+  commands:
+    - pip check
   imports:
     - OpenSSL
     - OpenSSL.crypto


### PR DESCRIPTION
Update pyopenssl to 21.0.0

Category:  miniconda | subcategory:  dependency | pkg_type:  python
Popularity:  12798042 downloads -  pyopenssl  21.0.0  Python wrapper module around the OpenSSL library
  license: Apache 2.0
Release date:  Sep 28, 2021
Bug Tracker: new open issues https://github.com/pyca/pyopenssl/issues
License file:  https://github.com/pyca/pyopenssl/blob/master/LICENSE
Upstream Changelog: https://github.com/pyca/pyopenssl/blob/main/CHANGELOG.rst
Upstream setup.py:  https://github.com/pyca/pyopenssl/blob/21.0.0/setup.py

The package pyopenssl is mentioned inside the packages:
airflow | certipy | cherrypy | conda | docker-py | eventlet | google-auth | ndg-httpsclient | quandl | scrapy | service_identity | trustme | twisted | urllib3 |

Actions:
1. Add missing packages: `setuptools`, `wheel`
2. Add `pip check`
3. Add `python <3.10` in test/requires
4. Update dependency: `cryptography >=3.3`

Result:
- all-succeeded