### PR TITLE
Bumped version.  Modified dependency requirements.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyopenssl" %}
-{% set version = "23.0.0" %}
+{% set version = "23.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyOpenSSL-{{ version }}.tar.gz
-  sha256: c1cc5f86bcacefc84dada7d31175cae1b1518d5f60d3d0bb595a67822a868a6f
+  sha256: 276f931f55a452e7dea69c7173e984eb2a4407ce413c918aa34b55f82f9b8bac
 
 build:
   # trigger 1
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - cryptography >=38.0.0,<40
+    - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
 
 test:
   imports:


### PR DESCRIPTION
diff between versions: https://github.com/pyca/pyopenssl/compare/23.0.0..23.2.0
Log:
- Bumped version
- Changed cryptography versions