### PR TITLE
Bumping version and hash.  Also lower bound of Python increased.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyopenssl" %}
-{% set version = "23.2.0" %}
+{% set version = "24.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyOpenSSL-{{ version }}.tar.gz
-  sha256: 276f931f55a452e7dea69c7173e984eb2a4407ce413c918aa34b55f82f9b8bac
+  sha256: 6aa33039a93fffa4563e655b61d11364d01264be8ccb49906101e02a334530bf
 
 build:
   # trigger 1
   number: 0
-  skip: true  # [py<36]
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+    - cryptography >=41.0.5,<43
 
 test:
   imports:


### PR DESCRIPTION
pyopenssl 24.0.0

**Destination channel:** {defaults}

### Links

- [{PKG-3901}](https://anaconda.atlassian.net/browse/PKG-3901) 
- [Upstream repository](https://github.com/pyca/pyopenssl)
- [Upstream changelog/diff](https://github.com/pyca/pyopenssl/compare/23.2.0..24.0.0)
- Relevant dependency PRs:
  - ...

### Explanation of changes:
- bumped version and hash
- Updated min python version
- Updated dependency constraints
