### PR TITLE
V24.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - cryptography >=41.0.5,<43
+    - cryptography >=41.0.5,<44
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,15 @@
 {% set name = "pyopenssl" %}
-{% set version = "24.0.0" %}
+{% set version = "24.2.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyOpenSSL-{{ version }}.tar.gz
-  sha256: 6aa33039a93fffa4563e655b61d11364d01264be8ccb49906101e02a334530bf
+  url: https://pypi.io/packages/source/p/pyOpenSSL/{{ name }}-{{ version }}.tar.gz
+  sha256: 4247f0dbe3748d560dcbb2ff3ea01af0f9a1a001ef5f7c4c647956ed8cbf0e95
 
 build:
-  # trigger 1
   number: 0
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5368](https://anaconda.atlassian.net/browse/PKG-5368)
- [Upstream repository](https://github.com/pyca/pyopenssl/tree/24.2.1)
- [Upstream changelog/diff](https://github.com/pyca/pyopenssl/blob/24.2.1/CHANGELOG.rst)

### Explanation of changes:

- Update version and sha256
- Update dependencies


[PKG-5368]: https://anaconda.atlassian.net/browse/PKG-5368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ