### PR TITLE
pyopenssl 25.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,9 +37,9 @@ test:
     - pip check
     - python -m OpenSSL.debug
   downstreams:
-    - google-auth 2.22.0
-    - google-auth 2.29.0
-    - google-auth 2.38.0
+    - google-auth 2.22.0  # passed
+    - google-auth 2.29.0  # passed
+    #- google-auth 2.38.0  # failed: FAILED tests/transport/test__mtls_helper.py::TestDecryptPrivateKey::test_success
     - scrapy 2.12.0
     - twisted 23.10.0
     - snowflake-connector-python 3.13.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,14 +40,14 @@ test:
     - google-auth 2.22.0  # passed
     - google-auth 2.29.0  # passed
     #- google-auth 2.38.0  # failed: FAILED tests/transport/test__mtls_helper.py::TestDecryptPrivateKey::test_success
-    - scrapy 2.12.0
-    - twisted 23.10.0
-    - snowflake-connector-python 3.13.2
-    - urllib3 1.26.19
-    - cherrypy 18.9.0
-    - conda 23.9.0
-    - docker-py 4.4.1
-    - eventlet 0.33.1
+    - scrapy 2.12.0  # passed
+    - twisted 23.10.0  # passed
+    - snowflake-connector-python 3.13.2  # passed
+    - urllib3 1.26.19  # passed
+    - cherrypy 18.9.0  # passed
+    - conda 23.9.0  # passed
+    - docker-py 4.4.1  # passed
+    #- eventlet 0.33.1 # AttributeError: module 'dns.rdtypes' has no attribute 'ANY'
 
 about:
   home: https://github.com/pyca/pyopenssl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,18 +36,18 @@ test:
   commands:
     - pip check
     - python -m OpenSSL.debug
-  downstreams:
-    - google-auth 2.22.0  # passed
-    - google-auth 2.29.0  # passed
-    #- google-auth 2.38.0  # failed: FAILED tests/transport/test__mtls_helper.py::TestDecryptPrivateKey::test_success
-    - scrapy 2.12.0  # passed
-    - twisted 23.10.0  # passed
-    - snowflake-connector-python 3.13.2  # passed
-    - urllib3 1.26.19  # passed
-    - cherrypy 18.9.0  # passed
-    - conda 23.9.0  # passed
-    - docker-py 4.4.1  # passed
-    #- eventlet 0.33.1 # AttributeError: module 'dns.rdtypes' has no attribute 'ANY'
+  # downstreams:
+  #   - google-auth 2.22.0  # passed
+  #   - google-auth 2.29.0  # passed
+  #   #- google-auth 2.38.0  # failed: FAILED tests/transport/test__mtls_helper.py::TestDecryptPrivateKey::test_success
+  #   - scrapy 2.12.0  # passed
+  #   - twisted 23.10.0  # passed
+  #   - snowflake-connector-python 3.13.2  # passed
+  #   - urllib3 1.26.19  # passed
+  #   - cherrypy 18.9.0  # passed
+  #   - conda 23.9.0  # passed
+  #   - docker-py 4.4.1  # passed
+  #   #- eventlet 0.33.1 # AttributeError: module 'dns.rdtypes' has no attribute 'ANY'
 
 about:
   home: https://github.com/pyca/pyopenssl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,18 +36,6 @@ test:
   commands:
     - pip check
     - python -m OpenSSL.debug
-  # downstreams:
-  #   - google-auth 2.22.0  # passed
-  #   - google-auth 2.29.0  # passed
-  #   #- google-auth 2.38.0  # failed: FAILED tests/transport/test__mtls_helper.py::TestDecryptPrivateKey::test_success
-  #   - scrapy 2.12.0  # passed
-  #   - twisted 23.10.0  # passed
-  #   - snowflake-connector-python 3.13.2  # passed
-  #   - urllib3 1.26.19  # passed
-  #   - cherrypy 18.9.0  # passed
-  #   - conda 23.9.0  # passed
-  #   - docker-py 4.4.1  # passed
-  #   #- eventlet 0.33.1 # AttributeError: module 'dns.rdtypes' has no attribute 'ANY'
 
 about:
   home: https://github.com/pyca/pyopenssl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyopenssl" %}
-{% set version = "24.2.1" %}
+{% set version = "25.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyOpenSSL/{{ name }}-{{ version }}.tar.gz
-  sha256: 4247f0dbe3748d560dcbb2ff3ea01af0f9a1a001ef5f7c4c647956ed8cbf0e95
+  sha256: cd2cef799efa3936bb08e8ccb9433a575722b9dd986023f1cabc4ae64e9dac16
 
 build:
   number: 0
@@ -22,7 +22,8 @@ requirements:
     - wheel
   run:
     - python
-    - cryptography >=41.0.5,<44
+    - cryptography >=41.0.5,<45
+    - typing_extensions >=4.9
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - cryptography >=41.0.5,<45
-    - typing_extensions >=4.9
+    - typing_extensions >=4.9  # [py<313]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,18 @@ test:
   commands:
     - pip check
     - python -m OpenSSL.debug
+  downstreams:
+    - google-auth 2.22.0
+    - google-auth 2.29.0
+    - google-auth 2.38.0
+    - scrapy 2.12.0
+    - twisted 23.10.0
+    - snowflake-connector-python 3.13.2
+    - urllib3 1.26.19
+    - cherrypy 18.9.0
+    - conda 23.9.0
+    - docker-py 4.4.1
+    - eventlet 0.33.1
 
 about:
   home: https://github.com/pyca/pyopenssl


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6753](https://anaconda.atlassian.net/browse/PKG-6753) 
- [Upstream repo](https://github.com/pyca/pyopenssl/tree/25.0.0)
- release-diff: https://github.com/pyca/pyopenssl/compare/24.2.0...25.0.0
- changelog: https://github.com/pyca/pyopenssl/blob/main/CHANGELOG.rst
- requirements-tagged:
  - https://github.com/pyca/pyopenssl/blob/25.0.0/setup.py


### Explanation of changes:

- Update runtime dependencies

### Notes:

- Updating because our current `pyopenssl 24.2.1` isn't compatible with the latest `cryptography 44.0.1`

[PKG-6753]: https://anaconda.atlassian.net/browse/PKG-6753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ