### PR TITLE
v26.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - cryptography >=45.0.7,<47
+    - cryptography >=46.0.0,<47
     - typing_extensions >=4.9  # [py<313]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyopenssl" %}
-{% set version = "25.3.0" %}
+{% set version = "26.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/p/pyOpenSSL/{{ name }}-{{ version }}.tar.gz
-  sha256: c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329
+  sha256: f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
pyopenssl v26.0.0

**Destination channel:**  defaults

### Links

- [PKG-13024](https://anaconda.atlassian.net/browse/PKG-13024) 
- [Upstream repository](https://github.com/pyca/pyopenssl/tree/26.0.0)
- [Upstream changelog/diff](https://github.com/pyca/pyopenssl/blob/26.0.0/CHANGELOG.rst)

### Explanation of changes:

- Bump version and sha
- Drop 3.7
- Update cryptography pin to match upstream


[PKG-13024]: https://anaconda.atlassian.net/browse/PKG-13024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ