### PR TITLE
pyopenssl 26.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyopenssl" %}
-{% set version = "26.0.0" %}
+{% set version = "26.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/p/pyOpenSSL/{{ name }}-{{ version }}.tar.gz
-  sha256: f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc
+  sha256: 8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - cryptography >=46.0.0,<47
+    - cryptography >=46.0.0,<49
     - typing_extensions >=4.9  # [py<313]
 
 test:


### PR DESCRIPTION
## pyopenssl 26.2.0

**Destination channel:** defaults

### Links
- [PKG-15165](https://anaconda.atlassian.net/browse/PKG-15165)
- [PyPI](https://pypi.org/project/pyopenssl/26.2.0/)
- https://github.com/pyca/pyopenssl/compare/26.0.0...26.2.0

### Explanation of changes:
- Updated pyopenssl from 26.0.0 to 26.2.0
- Updated cryptography dependency from >=46.0.0,<47 to >=46.0.0,<49 (matching upstream)
- Updated source SHA256

[PKG-15165]: https://anaconda.atlassian.net/browse/PKG-15165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ